### PR TITLE
fix: add permissions to workflows

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -136,6 +136,8 @@ jobs:
     runs-on: ubuntu-24.04
     environment: test
     needs: [build-web, build-backend]
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,6 +4,8 @@ jobs:
   check:
     name: Code check
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -33,6 +35,8 @@ jobs:
   build-web:
     name: Build web
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -43,6 +47,9 @@ jobs:
     name: Run E2E tests
     timeout-minutes: 15
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@v4
 
@@ -77,6 +84,8 @@ jobs:
   lint-backend:
     name: Lint backend
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -94,6 +103,8 @@ jobs:
   lint-sql:
     name: Lint SQL
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -111,6 +122,8 @@ jobs:
   test-backend:
     name: Test backend
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -125,6 +138,8 @@ jobs:
   build-backend:
     name: Build backend
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ jobs:
   build-web:
     name: Build web
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -15,6 +17,8 @@ jobs:
   build-backend:
     name: Build backend
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -26,6 +30,8 @@ jobs:
     runs-on: ubuntu-24.04
     environment: production
     needs: [build-web, build-backend]
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/climblive/platform/security/code-scanning/24](https://github.com/climblive/platform/security/code-scanning/24)

To fix the issue, we need to add a `permissions` block to the `deploy` job to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the `deploy` job primarily interacts with external systems and does not appear to require repository write access, we can set the permissions to `contents: read` as a minimal starting point. This ensures the job has only the necessary access to repository contents while preventing unintended write operations.

The changes will be made in the `.github/workflows/pull-request.yml` file, specifically within the `deploy` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
